### PR TITLE
Add Bounty Modifier, Options and Event (Not sure if functional | REQUIRES TESTING)

### DIFF
--- a/Events/Modifiers/BountyEvents.cs
+++ b/Events/Modifiers/BountyEvents.cs
@@ -9,10 +9,12 @@ namespace DivaniMods.Events.Modifiers;
 public static class BountyEvents
 {
     [RegisterEvent]
-public static void TaskCompleteEventHandler(TaskCompleteEvent e) {
-    var p = e.Player;
-    if (p.Data.IsDead()) return;
-
-    //todo: decrease Killer CD on Kill + Count tasks done
+public static void TaskCompleteEventHandler(TaskCompleteEvent e)
+    CountCompleted =>  GetNeeded(); {
+    
+    OnDeath TryGetKiller
+    Killer GetKillCooldown
+    KillCooldown => KillCooldown - OptionsGroupSingleton<BountyModifierOptions>.Instance.DecreasePerTask.Value * GetNeeded()
+    //todo: Does this work?
 }
 }

--- a/Events/Modifiers/BountyEvents.cs
+++ b/Events/Modifiers/BountyEvents.cs
@@ -1,0 +1,12 @@
+using HarmonyLib;
+using MiraAPI.Events;
+using MiraAPI.Events.Vanilla.Gameplay;
+using MiraAPI.Modifiers;
+using DivaniMods.Modifiers.Game.Crewmate;
+
+namespace DivaniMods.Events.Modifiers;
+
+public static class BountyEvents
+{
+    
+}

--- a/Events/Modifiers/BountyEvents.cs
+++ b/Events/Modifiers/BountyEvents.cs
@@ -11,10 +11,12 @@ public static class BountyEvents
     [RegisterEvent]
 public static void TaskCompleteEventHandler(TaskCompleteEvent e)
     CountCompleted =>  GetNeeded(); {
-    
+    Var killer = AfterMurderEvent.Source;
+    Var target = AfterMurderEvent.Target;
+
     OnDeath TryGetKiller
-    Killer GetKillCooldown
+    killer GetKillCooldown
     KillCooldown => KillCooldown - OptionsGroupSingleton<BountyModifierOptions>.Instance.DecreasePerTask.Value * GetNeeded()
-    //todo: Does this work?
+    //todo: Does this work? + Notif for Killer: "You`ve killed the Bounty, your Kill Cooldown is now OptionsGroupSingleton<BountyModifierOptions>.Instance.DecreasePerTask.Value * GetNeeded() seconds shorter than usual!"
 }
 }

--- a/Events/Modifiers/BountyEvents.cs
+++ b/Events/Modifiers/BountyEvents.cs
@@ -8,5 +8,11 @@ namespace DivaniMods.Events.Modifiers;
 
 public static class BountyEvents
 {
-    
+    [RegisterEvent]
+public static void TaskCompleteEventHandler(TaskCompleteEvent e) {
+    var p = e.Player;
+    if (p.Data.IsDead()) return;
+
+    //todo: decrease Killer CD on Kill + Count tasks done
+}
 }

--- a/Modifiers/Game/Crewmate/BountyModifier.cs
+++ b/Modifiers/Game/Crewmate/BountyModifier.cs
@@ -1,0 +1,43 @@
+using IlCppInterop.Runtime.Attributes;
+using AmongUs.GameOptions;
+using MiraAPI.GameOptions;
+using MiraAPI.Roles;
+using MiraAPI.Utilities.Assets;
+using DivaniMods.Assets;
+using DivaniMods.Options;
+using TownOfUs.Interfaces;
+using TownOfUs.Modifiers;
+using TownOfUs.Modifiers.Game;
+using TownOfUs.Modules.Wiki;
+using TownOfUs.Utilities;
+using UnityEngine;
+
+namespace DivaniMods.Modifiers.Game.Crewmate;
+
+public sealed class BountyModifier : TOUGameModifier, IColoredModifier, IWikiDiscoverable
+{
+    public static readonly Color BountyColor = new Color32(66, 33, 99, 255);
+
+    public override string ModifierName => "Bounty";
+    public override string LocaleKey => "Bounty";
+    public override string IntroInfo => "The more tasks you do, the higher your bounty.";
+    public override ModifierFaction FactionType => ModifierFaction.Crewmate.Postmortem;
+    public override Color ModifierColor => BountyColor;
+    public override LoadableAsset<Sprite>? ModifierIcon => DivaniAssets.BountyIcon;
+
+    public override string GetDescription() => "Every time you do a task, your bounty raises, once you die your KIller has their Kill Cooldown decreased by a set percent for every task done.";
+
+    public string GetAdvancedDescription() => GetDescription() + MiscUtils.AppendOptionsText(GetType());
+
+    public override int GetAssignmentChance() => (Int)OptionGroupSingleton<CrewmateModifierOptions>.Instance.Bountychance.Value;
+
+    public override GetAmountPerGame() => (Int)OptionGroupSingleton<CrewmateModifierOptions>.Instance.Bountychance.Value;
+
+    public override bool IsModifierValidOn(RoleBehaviour Role)
+   {
+        return role.IsCrewmate() && base.IsModifierValidOn(role) && !ModifierExclusions.ConflictsWithOwned(role.player, this),      
+   } 
+   public override void OnActivate();
+   {
+   }
+}

--- a/Options/Modifiers/Game/Crewmate/BountyOptions.cs
+++ b/Options/Modifiers/Game/Crewmate/BountyOptions.cs
@@ -1,0 +1,24 @@
+using System;
+using MiraAPI.GameOptions;
+using MiraAPI.GameOptions.Attributes;
+using MiraAPI.GameOptions.OptionTypes;
+using MiraAPI.Utilities;
+using DivaniMods.Modifiers.Game.Crewmate;
+using TownOfUs.Options;
+using UnityEngine;
+
+namespace DivaniMods.Options;
+
+public sealed class BountyOptions : AbstractOptionGroup<BountyModifier>
+{
+    public override Func<bool> GroupVisible => () => OptionsGroupSingleton<RoleOptions>.Instance.IsClassicRoleAssignment;
+    
+    public override string GroupName => "Bounty";
+
+    public override Color GroupColor => BountyColor;
+
+    public override uint GroupPriority => 26;
+
+    public ModdedNumberOption DecreasePerTask  { get; } = new(
+        "cooldown decrease per task (Killer)", 2.5f, 0.5f, 15f, 0.5f, MiraNumberSuffixes.Seconds);
+}

--- a/Roles/Neutral/NeutralKilling/WatcherRole.cs
+++ b/Roles/Neutral/NeutralKilling/WatcherRole.cs
@@ -24,7 +24,7 @@ using UnityEngine;
 namespace DivaniMods.Roles.Neutral.NeutralKilling;
 
 public sealed class WatcherRole(IntPtr cppPtr)
-    : NeutralRole(cppPtr), ITownOfUsRole, IWikiDiscoverable, IDoomable
+    : NeutralRole(cppPtr), ITownOfUsRole, IWikiDiscoverable, IDoomable, ICrewVariant
 {
     public static readonly Color WatcherColor = new Color32(0xD3, 0xA6, 0x35, 255);
     public static readonly Color GreenLightColor = new Color32(0x7C, 0xCE, 0x34, 255);
@@ -41,6 +41,9 @@ public sealed class WatcherRole(IntPtr cppPtr)
     public RoleAlignment RoleAlignment => RoleAlignment.NeutralKilling;
 
     public DoomableType DoomHintType => DoomableType.Fearmonger;
+
+    public RoleBehaviour CrewVariant =>
+        RoleManager.Instance.GetRole((RoleTypes)RoleId.Get<SentryRole>());
 
     public bool HasImpostorVision => true;
 


### PR DESCRIPTION
This PR adds the Bounty Modifier:

**Bounty**
Bounty is a Modifier given to a Crewmate and listed as a Postmortem modifier, every time you do a task your Bounty rises. After your death, your killer will have a lower kill cooldown depending on your Bounty.
Todo if it works: 
● Create Notification for the killer
● Add a temporary shield to the Bounty after every task [Buff]